### PR TITLE
API-8688: wait for DB status update before returning message

### DIFF
--- a/app/uk/gov/hmrc/apiplatformoutboundsoap/repositories/OutboundMessageRepository.scala
+++ b/app/uk/gov/hmrc/apiplatformoutboundsoap/repositories/OutboundMessageRepository.scala
@@ -27,7 +27,7 @@ import org.apache.pekko.stream.scaladsl.Source
 import org.bson.codecs.configuration.CodecRegistries._
 import org.mongodb.scala.ReadPreference.primaryPreferred
 import org.mongodb.scala.bson.collection.immutable.Document
-import org.mongodb.scala.model.Filters.{and, equal, lte, or}
+import org.mongodb.scala.model.Filters.{and, equal, lte, not, or}
 import org.mongodb.scala.model.Indexes.ascending
 import org.mongodb.scala.model.Sorts.descending
 import org.mongodb.scala.model.Updates.{combine, set}
@@ -157,17 +157,18 @@ class OutboundMessageRepository @Inject() (mongoComponent: MongoComponent, appCo
       case DeliveryStatus.COE => "coeMessage"
     }
 
-    for {
-      _           <- collection.bulkWrite(
-                       List(UpdateManyModel(Document("messageId" -> messageId), combine(set("status", Codecs.toBson(newStatus.toString)), set(field, confirmationMsg)))),
-                       BulkWriteOptions().ordered(false)
-                     ).toFuture()
-      findUpdated <- findById(messageId)
-    } yield findUpdated
+    collection.bulkWrite(
+      List(UpdateManyModel(Document("messageId" -> messageId), combine(set("status", Codecs.toBson(newStatus.toString)), set(field, confirmationMsg)))),
+      BulkWriteOptions().ordered(false)
+    ).toFuture().flatMap(_ => findById(messageId))
   }
 
   def findById(searchForId: String): Future[Option[OutboundSoapMessage]] = {
-    val findQuery = or(Document("messageId" -> searchForId), Document("globalId" -> searchForId))
+    val queryFilterMsgId  = or(Document("messageId" -> searchForId), Document("globalId" -> searchForId))
+    // PENDING status exists only for the brief period between sending a message being requested and CCN2 responding.
+    // This status should never be exposed to any external service so we ignore it here
+    val queryFilterStatus = not(Document("status" -> "PENDING"))
+    val findQuery         = and(queryFilterMsgId, queryFilterStatus)
     collection.find(findQuery).sort(descending("createDateTime")).headOption()
       .recover {
         case e: Exception =>

--- a/it/test/uk/gov/hmrc/apiplatformoutboundsoap/repositories/OutboundMessageRepositoryISpec.scala
+++ b/it/test/uk/gov/hmrc/apiplatformoutboundsoap/repositories/OutboundMessageRepositoryISpec.scala
@@ -380,6 +380,13 @@ class OutboundMessageRepositoryISpec extends AnyWordSpec with DefaultPlayMongoRe
       found shouldBe truncateSentMessageInstants(messageToPersist)
     }
 
+    "not return message with PENDING state" in {
+      val messageToPersist                   = pendingOutboundSoapMessage
+      await(repository.persist(messageToPersist))
+      val found: Option[OutboundSoapMessage] = await(repository.findById(messageToPersist.messageId))
+      found shouldBe None
+    }
+
     "return message when globalId matches" in {
       await(repository.persist(sentOutboundSoapMessage))
       val Some(found): Option[OutboundSoapMessage] = await(repository.findById(sentOutboundSoapMessage.globalId.toString))

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 
 object AppDependencies {
   val bootstrapPlayVersion = "9.19.0"
-  val mongoVersion         = "2.7.0"
+  val mongoVersion         = "2.10.0"
   val compile = Seq(
     "uk.gov.hmrc"         %% "bootstrap-backend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"   %% "hmrc-mongo-play-30"        % mongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ resolvers += Resolver.typesafeRepo("releases")
 
 addSbtPlugin("uk.gov.hmrc"       % "sbt-auto-build"        % "3.24.0")
 addSbtPlugin("uk.gov.hmrc"       % "sbt-distributables"    % "2.6.0")
-addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.8")
+addSbtPlugin("org.playframework" % "sbt-plugin"            % "3.0.9")
 addSbtPlugin("org.scalastyle"    % "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage"     % "sbt-scoverage"         % "2.3.1")
 addSbtPlugin("org.scalameta"     % "sbt-scalafmt"          % "2.5.2")

--- a/test/uk/gov/hmrc/apiplatformoutboundsoap/services/OutboundServiceSpec.scala
+++ b/test/uk/gov/hmrc/apiplatformoutboundsoap/services/OutboundServiceSpec.scala
@@ -438,6 +438,18 @@ class OutboundServiceSpec extends AnyWordSpec with TestDataFactory with Matchers
       messageCaptor.getValue.messageId shouldBe messageId
     }
 
+    "handle failure to retrieve message from database after status update" in new Setup {
+      when(wsSecurityServiceMock.addUsernameToken(*)).thenReturn(expectedSoapEnvelope(allAddressingHeaders))
+      when(outboundConnectorMock.postMessage(*, *)).thenReturn(successful(expectedStatus))
+      val messageCaptor: ArgumentCaptor[OutboundSoapMessage] = ArgumentCaptor.forClass(classOf[OutboundSoapMessage])
+      when(outboundMessageRepositoryMock.persist(messageCaptor.capture())).thenReturn(Future(InsertOneResult.acknowledged(BsonNumber(1))))
+      when(outboundMessageRepositoryMock.updateSendingStatus(*, *, *)).thenReturn(Future(Option.empty))
+
+      await(underTest.sendMessage(messageRequestMinimalAddressing))
+
+      verify(notificationCallbackConnectorMock, times(0)).sendNotification(*)(*)
+    }
+
     "persist message ID if present in the request for failure" in new Setup {
       when(wsSecurityServiceMock.addUsernameToken(*)).thenReturn(expectedSoapEnvelope(allAddressingHeaders))
       when(outboundConnectorMock.postMessage(*, *)).thenReturn(successful(INTERNAL_SERVER_ERROR))


### PR DESCRIPTION
Also, hide PENDING messages from external view by ensuring that Mongo queries won't return such messages